### PR TITLE
Mention Command Line Tools Requirement in ReadMe.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The required version of Xcode changes frequently, and is often a beta release.
 Check this document or the host information on <https://ci.swift.org> for the
 current required version.
 
+In Xcode Preferences, on the Locations tab, Command Line Tools should be set to Xcode 10.0 (10L176w).
+
 You will also need [CMake](https://cmake.org) and [Ninja](https://ninja-build.org),
 which can be installed via a package manager:
 


### PR DESCRIPTION
<!-- What's in this pull request? -->
The README.md explanation of the required development environment mentions that Xcode 10 Beta is required, but makes no mention of (1) the possibility that the Command Line Tools preference of Xcode 10 may default to 9.4.1, or (2) the requirement that Command Line Tools be set to Xcode 10.0.  As reflected in Swift Forums posts, this requirement has caused some frustration, and that frustration is not limited to the inexperienced (e.g., [Erica Sadun fell victim to it](https://forums.swift.org/t/error-building-swift-swift-does-not-support-the-sdk-macosx10-13-sdk/13701)).

<!-- If this pull request resolves any bugs in the Swift bug tracker, provide a link: -->
This does not resolve a bug.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->